### PR TITLE
Move dev dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,7 @@
   },
   "homepage": "https://github.com/material-table-core/exporters#readme",
   "dependencies": {
-    "@types/node": "^20.8.10",
     "filefy": "^0.1.11",
-    "jest-environment-jsdom": "^29.7.0",
     "jspdf": "^2.5.1",
     "jspdf-autotable": "^3.6.0"
   },
@@ -51,9 +49,11 @@
     "@babel/preset-env": "^7.23.2",
     "@material-table/core": "^6.0.0",
     "@types/jest": "^29.5.7",
+    "@types/node": "^20.8.10",
     "babel-jest": "^29.7.0",
     "generate-changelog": "^1.8.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "ts-jest": "^29.1.1",
     "tshy": "^1.7.0",
     "typescript": "^5.2.2"


### PR DESCRIPTION
Move dev dependencies to `devDependencies` to prevent dev packages from installing in client-side consuming projects. This change has no effect on the `package-lock.json` for this `exporters` project, but improves install size in consuming projects.

Currently our `yarn.lock` installs all dependencies. We would prefer it if Jest dependencies were not installed in our project.

```
"@material-table/exporters@npm:~1.2.17":
  version: 1.2.17
  resolution: "@material-table/exporters@npm:1.2.17"
  dependencies:
    "@types/node": ^20.8.10
    filefy: ^0.1.11
    jest-environment-jsdom: ^29.7.0
    jspdf: ^2.5.1
    jspdf-autotable: ^3.6.0
  peerDependencies:
    "@material-table/core": "*"
```