### PR TITLE
Update jspdf dependencies to fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "filefy": "^0.1.11",
-        "jspdf": "^2.5.1",
-        "jspdf-autotable": "^3.6.0"
+        "jspdf": "^4.0.0",
+        "jspdf-autotable": "^5.0.7"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.23.2",
@@ -1657,30 +1657,12 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
-      "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
-      "optional": true,
-      "dependencies": {
-        "core-js-pure": "^3.0.0",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.22.15",
@@ -3621,6 +3603,11 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.1.tgz",
@@ -3634,9 +3621,9 @@
       "peer": true
     },
     "node_modules/@types/raf": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
-      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
       "optional": true
     },
     "node_modules/@types/react": {
@@ -3676,6 +3663,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.3.tgz",
       "integrity": "sha512-THo502dA5PzG/sfQH+42Lw3fvmYkceefOspdCwpHRul8ik2Jv1K8I5OZz1AT3/rs46kwgMCe9bSBmDLYkkOMGg==",
       "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -3809,17 +3802,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
-    },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -4157,17 +4139,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4212,20 +4183,22 @@
       ]
     },
     "node_modules/canvg": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.7.tgz",
-      "integrity": "sha512-4sq6iL5Q4VOXS3PL1BapiXIZItpxYyANVzsAKpTPS5oq4u3SKbGfUcbZh2gdLCQ3jWpG/y5wRkMlBBAJhXeiZA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
       "optional": true,
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.9.6",
+        "@babel/runtime": "^7.12.5",
         "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
         "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
         "rgbcolor": "^1.0.1",
         "stackblur-canvas": "^2.0.0",
-        "svg-pathdata": "^5.0.5"
+        "svg-pathdata": "^6.0.3"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/chalk": {
@@ -4421,18 +4394,6 @@
       "dependencies": {
         "browserslist": "^4.22.1"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.3.tgz",
-      "integrity": "sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==",
-      "deprecated": "core-js-pure@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js-pure.",
-      "hasInstallScript": true,
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -4750,10 +4711,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
-      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ==",
-      "optional": true
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -5027,6 +4991,16 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -5037,9 +5011,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
     },
     "node_modules/filefy": {
       "version": "0.1.11",
@@ -5429,6 +5403,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA=="
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -7949,28 +7928,27 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
-      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
+      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
       "dependencies": {
-        "@babel/runtime": "^7.14.0",
-        "atob": "^2.1.2",
-        "btoa": "^1.2.1",
-        "fflate": "^0.4.8"
+        "@babel/runtime": "^7.28.4",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
       },
       "optionalDependencies": {
-        "canvg": "^3.0.6",
+        "canvg": "^3.0.11",
         "core-js": "^3.6.0",
-        "dompurify": "^2.2.0",
+        "dompurify": "^3.2.4",
         "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jspdf-autotable": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-3.6.0.tgz",
-      "integrity": "sha512-CxO+/WylWNpwEzRLoYXrBoYpv+GeWijZFn2nqGevzMaqqMr2acC5eRgBCaBNtoipzpyfBFbCdG/UsG1eonoLrw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.7.tgz",
+      "integrity": "sha512-2wr7H6liNDBYNwt25hMQwXkEWFOEopgKIvR1Eukuw6Zmprm/ZcnmLTQEjW7Xx3FCbD3v7pflLcnMAv/h1jFDQw==",
       "peerDependencies": {
-        "jspdf": "^2.5.1"
+        "jspdf": "^2 || ^3 || ^4"
       }
     },
     "node_modules/kleur": {
@@ -8282,6 +8260,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8392,7 +8375,7 @@
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "optional": true
     },
     "node_modules/picocolors": {
@@ -8642,9 +8625,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "optional": true
     },
     "node_modules/regenerator-transform": {
@@ -8820,7 +8803,7 @@
     "node_modules/rgbcolor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-      "integrity": "sha1-1lBezbMEplldom+ktDMHMGd1lF0=",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
       "optional": true,
       "engines": {
         "node": ">= 0.8.15"
@@ -9016,9 +8999,9 @@
       }
     },
     "node_modules/stackblur-canvas": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.4.0.tgz",
-      "integrity": "sha512-Z+HixfgYV0ss3C342DxPwc+UvN1SYWqoz7Wsi3xEDWEnaBkSCL3Ey21gF4io+WlLm8/RIrSnCrDBIEcH4O+q5Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
       "optional": true,
       "engines": {
         "node": ">=0.1.14"
@@ -9150,12 +9133,12 @@
       }
     },
     "node_modules/svg-pathdata": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-5.0.5.tgz",
-      "integrity": "sha512-TAAvLNSE3fEhyl/Da19JWfMAdhSXTYeviXsLSoDT1UM76ADj5ndwAPX1FKQEgB/gFMPavOy6tOqfalXKUiXrow==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
       "optional": true,
       "engines": {
-        "node": ">=6.9.5"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   "homepage": "https://github.com/material-table-core/exporters#readme",
   "dependencies": {
     "filefy": "^0.1.11",
-    "jspdf": "^2.5.1",
-    "jspdf-autotable": "^3.6.0"
+    "jspdf": "^4.0.0",
+    "jspdf-autotable": "^5.0.7"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.23.2",

--- a/src/pdf/index.test.js
+++ b/src/pdf/index.test.js
@@ -1,0 +1,82 @@
+import { ExportPdf } from "./index";
+
+const mockApplyPlugin = jest.fn();
+const mockJspdf = jest.fn();
+let mockJspdfConstructor;
+
+jest.mock("jspdf", () => {
+  mockJspdfConstructor = function (...args) {
+    return mockJspdf(...args);
+  };
+
+  return {
+    __esModule: true,
+    default: mockJspdfConstructor,
+  };
+});
+
+jest.mock("jspdf-autotable", () => ({
+  __esModule: true,
+  applyPlugin: (...args) => mockApplyPlugin(...args),
+}));
+
+describe("Tests pdf export", () => {
+  let docMock;
+
+  beforeEach(() => {
+    docMock = {
+      setFontSize: jest.fn(),
+      text: jest.fn(),
+      autoTable: jest.fn(),
+      save: jest.fn(),
+    };
+    mockJspdf.mockClear();
+    mockApplyPlugin.mockClear();
+    mockJspdf.mockReturnValue(docMock);
+  });
+
+  it("saves a pdf with the default filename", () => {
+    ExportPdf([
+      {
+        title: "Name",
+        field: "name",
+      },
+    ]);
+
+    expect(mockApplyPlugin).toHaveBeenCalledWith(mockJspdfConstructor);
+    expect(mockJspdf).toHaveBeenCalledWith("landscape", "pt", "A4");
+    expect(docMock.text).toHaveBeenCalledWith("data", 40, 40);
+    expect(docMock.autoTable).toHaveBeenCalledWith({
+      startY: 50,
+      head: [["Name"]],
+      body: [],
+    });
+    expect(docMock.save).toHaveBeenCalledWith("data.pdf");
+  });
+
+  it("transforms object rows and uses exportTransformer", () => {
+    ExportPdf(
+      [
+        { title: "Name", field: "name" },
+        {
+          title: "Secret",
+          field: "secret",
+          exportTransformer: (row) => row.hidden || "No hidden",
+        },
+      ],
+      [
+        { name: "Alice", secret: "ignored", hidden: "Top Secret" },
+        { name: "Bob", secret: "ignored" },
+      ],
+      "Report"
+    );
+
+    expect(docMock.autoTable).toHaveBeenCalledWith({
+      startY: 50,
+      head: [["Name", "Secret"]],
+      body: [["Alice", "Top Secret"], ["Bob", "No hidden"]],
+    });
+    expect(docMock.text).toHaveBeenCalledWith("Report", 40, 40);
+    expect(docMock.save).toHaveBeenCalledWith("Report.pdf");
+  });
+});

--- a/src/pdf/index.ts
+++ b/src/pdf/index.ts
@@ -1,6 +1,7 @@
 import JSpdf from "jspdf";
 import "jspdf-autotable";
 import { Column } from "@material-table/core";
+import { applyPlugin } from "jspdf-autotable";
 
 export function ExportPdf<T extends object>(
   columns: Array<Column<T>>,
@@ -33,6 +34,10 @@ export function ExportPdf<T extends object>(
     const unit = "pt";
     const size = "A4";
     const orientation = "landscape";
+
+    // This is now required in non browser environments to use the old
+    // way of calling autoTable on the jspdf doc instance.
+    applyPlugin(JSpdf)
     const doc = new JSpdf(orientation, unit, size) as JSpdf & {
       autoTable: (content: object) => void;
     };


### PR DESCRIPTION
Fixes included for at least a critical and high security vulnerability:
- https://github.com/parallax/jsPDF/security/advisories/GHSA-f8cm-6447-x5h2
- https://github.com/advisories/GHSA-w532-jxjh-hjhj

Also adds some basic unit tests for the PDF export.

Fixes https://github.com/material-table-core/exporters/issues/15

Background: I use a package where this exporter is a dependency of a dependency and I would like to address the critical findings.